### PR TITLE
To solve the problems when input successive words from the start.

### DIFF
--- a/ch05/ex5_14.cpp
+++ b/ch05/ex5_14.cpp
@@ -12,7 +12,7 @@ int main()
 	if (str == prestr) { ++count;}
 	else count = 1;
 
-	if (count > max_duplicated.second + 1) {
+	if (count > max_duplicated.second && count >= 2) {
 		max_duplicated = { prestr, count };
 	}
     }


### PR DESCRIPTION
In the previous version, when you successively input same strings, then end the loop by ctrl+z(windows), the result is no duplicated words, which is not accord with our input.(eg. input three "123" and then ended with ctrl+z). 
The reason is that if the inputs are same from start, we will never enter the else branch where assign value to variable 'max_duplicated'.
So the operation on 'max_duplicated' should be done only when the 'count > max_duplicated.second && count >= 2', which shows that continuously duplicated inputs are tested. And when the current input is not same with the previous, we should set the count for the new string to 1.
