### PR TITLE
Update ex7_27.cpp

### DIFF
--- a/ch07/ex7_27.cpp
+++ b/ch07/ex7_27.cpp
@@ -17,7 +17,7 @@ public:
 
     //!  constructs:
     wyScreen() = default;
-    wyScreen(const pos h, const pos w) : height(h), width(w), contents(" ", h * w) {  }
+    wyScreen(const pos h, const pos w) : height(h), width(w), contents(h * w,' ') {  }
     wyScreen(const pos h, const pos w, char c) : height(h), width(w), contents(h * w, c){  }
 
     wyScreen &move(const pos r, const pos c);


### PR DESCRIPTION
I use  following codes test the  differences of "contents(" ", h \* w)" and  " contents(h \* w,'  ') "

```
std::string a( "a", 10 );
for (auto i : a)
    std::cout << i;
std::cout << std::endl;
std::string b(10,'b' );
for (auto i : b)
    std::cout << i;
```
