### PR TITLE
avoid double delete in commented move-assignment operator.

### DIFF
--- a/ch13/ex13_53.cpp
+++ b/ch13/ex13_53.cpp
@@ -48,6 +48,7 @@ HasPtr& HasPtr::operator=(HasPtr rhs)
 //        delete ps;
 //        ps = rhs.ps;
 //        i = rhs.i;
+//        rhs.ps = nullptr;
 //        std::cout << "call move assignment" << std::endl;
 //    }
 //    return *this;


### PR DESCRIPTION
If you don't set rhs.ps to nullptr both operands will be pointing to the same memory and eventually will end up doing 'delete' twice on that same memory. Valgrind --tool=memcheck confirms it.

P/S: I admire your effort and often learn things by comparing my code with yours. Thank you.