### PR TITLE
A litte change in ch02 ex2.27 about reference

### DIFF
--- a/ch02/README.md
+++ b/ch02/README.md
@@ -416,7 +416,7 @@ int *const p2 = &i2;        // legal.
 const int i = -1, &r = 0;   // legal.
 const int *const p3 = &i2;  // legal.
 const int *p1 = &i2;        // legal
-const int &const r2;        // illegal, r2 must initialize.
+const int &const r2;        // illegal, r2 is a reference that cannot be const.
 const int i2 = i, &r = i;   // legal.
 ```
 


### PR DESCRIPTION
In fifth edition section 2.41, it says
> Technically speaking, there are no const references. A reference is not an object, so we cannot make a reference itself const.

My test code shows the error message
>ch2_constRef2.cpp: 7:19: error: 'const' qualifiers cannot be applied to 'const int&'
const int & const r1 = i;
                   ^

It's may be not about initialization of a reference.


