### PR TITLE
fixed a serious bug may cause an infinite loop.

### DIFF
--- a/ch09/ex9_43.cpp
+++ b/ch09/ex9_43.cpp
@@ -2,36 +2,52 @@
 //  ex9_43.cpp
 //  Exercise 9.43
 //
-//  Created by pezy on 12/4/14.
-//  Copyright (c) 2014 pezy. All rights reserved.
+//  Created by XDXX on 4/16/2015.
+//  Copyright (c) 2015 XDXX. All rights reserved.
 //
 //  @Brief  Write a function that takes three strings, s, oldVal, and newVal.
 //          Using iterators, and the insert and erase functions replace
 //          all instances of oldVal that appear in s by newVal.
-//          Test your function by using it to replace common abbreviations,
+//	    Test your function by using it to replace common abbreviations,
 //          such as “tho” by “though” and “thru” by “through”.
 
+
+
+#include <iterator>
 #include <iostream>
 #include <string>
 
 using std::cout; using std::endl; using std::string;
 
-void func(string &s, const string &oldVal, const string &newVal)
+void func(string &s, const string oldVal, const string newVal)
 {
-    for (string::size_type i=0; i!=s.size(); ++i)
-        if (s.substr(i, oldVal.size()) == oldVal)
-            {
-                s.erase(i, oldVal.size());
-                s.insert(i, newVal);
-            }
+	for (auto iter = s.begin(); iter != s.end();)
+	{
+		if (s.end() - iter < oldVal.size())
+			break;
+		if (*iter == oldVal[0])
+		{
+			string substring{ iter, iter + oldVal.size() };
+			if (oldVal == substring)
+			{
+				iter = s.erase(iter, iter + oldVal.size());
+				iter = s.insert(iter, newVal.begin(), newVal.end());
+				iter += newVal.size();
+			}
+			else
+				++iter;
+		}
+		else
+			++iter;
+	}
 }
 
-int main()
+int main() 
 {
-    string str{"To drive straight thru is a foolish, tho courageous act."};
-    func(str, "tho", "though");
-    func(str, "thru", "through");
-    cout << str << endl;
+	string s{ "To drive straight thru is a foolish, tho courageous act." };
+	func(s, "tho", "though");
+	func(s, "thru", "through");
+	cout << s << endl;
 
-    return 0;
+	return 0;
 }

--- a/ch09/ex9_43.cpp
+++ b/ch09/ex9_43.cpp
@@ -11,9 +11,9 @@
 //	    Test your function by using it to replace common abbreviations,
 //          such as “tho” by “though” and “thru” by “through”.
 //  @notice This program doesn't compile on GCC because GCC(4.9.2) doesn't 
-	    support the feature of c++11 which the
-            insert(iterator p, InputIterator first, InputIterator last) function
-	    could return an iterator.So please use VS(2012+) or clang instead.
+//	    support the feature of c++11 which the
+//          insert(iterator p, InputIterator first, InputIterator last) function
+//	    could return an iterator.So please use VS(2012+) or clang instead.
 
 #include <iterator>
 #include <iostream>

--- a/ch09/ex9_43.cpp
+++ b/ch09/ex9_43.cpp
@@ -10,8 +10,10 @@
 //          all instances of oldVal that appear in s by newVal.
 //	    Test your function by using it to replace common abbreviations,
 //          such as “tho” by “though” and “thru” by “through”.
-
-
+//  @notice This program doesn't compile on GCC because GCC(4.9.2) doesn't 
+	    support the feature of c++11 which the
+            insert(iterator p, InputIterator first, InputIterator last) function
+	    could return an iterator.So please use VS(2012+) or clang instead.
 
 #include <iterator>
 #include <iostream>
@@ -19,7 +21,7 @@
 
 using std::cout; using std::endl; using std::string;
 
-void func(string &s, const string oldVal, const string newVal)
+void func(string &s, const string &oldVal, const string &newVal)
 {
 	for (auto iter = s.begin(); iter != s.end();)
 	{

--- a/ch09/ex9_43_1.cpp
+++ b/ch09/ex9_43_1.cpp
@@ -2,46 +2,35 @@
 //  ex9_43.cpp
 //  Exercise 9.43
 //
-//  Created by XDXX on 4/16/2015.
+//  Created by XDXX on 4/17/2015.
 //  Copyright (c) 2015 XDXX. All rights reserved.
 //
 //  @Brief  Write a function that takes three strings, s, oldVal, and newVal.
 //          Using iterators, and the insert and erase functions replace
 //          all instances of oldVal that appear in s by newVal.
-//	    Test your function by using it to replace common abbreviations,
+//	    	Test your function by using it to replace common abbreviations,
 //          such as “tho” by “though” and “thru” by “through”.
 //  @notice This program doesn't compile on GCC because GCC(4.9.2) doesn't 
-//	    support the feature of c++11 which the
+//	   		support the feature of c++11 which the
 //          insert(iterator p, InputIterator first, InputIterator last) function
-//	    could return an iterator.So please use VS(2012+) or clang instead.
+//	    	could return an iterator.So please use VS(2012+) or clang instead.
+//			Or you can see the cross-platform version(ex9_43_2.cpp) of this exercise.
 
 #include <iterator>
 #include <iostream>
 #include <string>
+#include <cstddef>
 
 using std::cout; using std::endl; using std::string;
 
-void func(string &s, const string &oldVal, const string &newVal)
+void func(string &s, string const& oldVal, string const& newVal)
 {
-	for (auto iter = s.begin(); iter != s.end();)
-	{
-		if (s.end() - iter < oldVal.size())
-			break;
-		if (*iter == oldVal[0])
-		{
-			string substring{ iter, iter + oldVal.size() };
-			if (oldVal == substring)
-			{
-				iter = s.erase(iter, iter + oldVal.size());
-				iter = s.insert(iter, newVal.begin(), newVal.end());
-				iter += newVal.size();
-			}
-			else
-				++iter;
-		}
-		else
-			++iter;
-	}
+    for (auto iter = s.begin(); std::distance(iter, s.end()) >= static_cast<ptrdiff_t>(oldVal.size()); )
+        if (*iter == oldVal[0] && string(iter, std::next(iter, oldVal.size())) == oldVal) {
+            iter = s.erase(iter, iter + oldVal.size());
+            iter = s.insert(iter, newVal.begin(), newVal.end());
+            iter += newVal.size();
+        } else  ++iter;
 }
 
 int main() 

--- a/ch09/ex9_43_2.cpp
+++ b/ch09/ex9_43_2.cpp
@@ -1,0 +1,43 @@
+//
+//  ex9_43_2.cpp
+//  Exercise 9.43
+//
+//  Created by pezy on 4/17/2015.
+//  Copyright (c) 2015 pezy. All rights reserved.
+//
+//  @Brief  Write a function that takes three strings, s, oldVal, and newVal.
+//          Using iterators, and the insert and erase functions replace
+//          all instances of oldVal that appear in s by newVal.
+//	    	Test your function by using it to replace common abbreviations,
+//          such as “tho” by “though” and “thru” by “through”.
+//  @notice This program could compiled with GCC well.But it doesn't use some c++11
+//          features.There is another version(ex9_43_1.cpp) of this exercise which
+//          using c++11 features.
+
+#include <iterator>
+#include <iostream>
+#include <string>
+#include <cstddef>
+
+using std::cout; using std::endl; using std::string;
+
+void func(string &s, string const& oldVal, string const& newVal)
+{
+    for (auto iter = s.begin(); std::distance(iter, s.end()) >= static_cast<ptrdiff_t>(oldVal.size()); )
+        if (*iter == oldVal[0] && string(iter, std::next(iter, oldVal.size())) == oldVal) {
+            iter = s.erase(iter, std::next(iter, oldVal.size()));
+            size_t pos = std::distance(s.begin(), iter) + newVal.size();
+            s.insert(iter, newVal.begin(), newVal.end());
+            iter = std::next(s.begin(), pos);
+        } else  ++iter;
+}
+
+int main() 
+{
+	string s{ "To drive straight thru is a foolish, tho courageous act." };
+	func(s, "tho", "though");
+	func(s, "thru", "through");
+	cout << s << endl;
+
+	return 0;
+}


### PR DESCRIPTION
The current version has a serious bug which may cause an infinite loop.This bug will appear  when the oldVal is a substring of the newVal(eg: oldVal = "tho", newVal = "tthough").
What's more, the exercise requires using iterators but the current version doesn't using any iterators.
My version is tested in Visual Studio 2013.But it can't pass the compilation in gcc 4.9.2 because gcc 4.9.2 doesn't support the c++11 feature "iterator insert (iterator p, InputIterator first, InputIterator last);".