### PR TITLE
ex5_10:default switch behavior

### DIFF
--- a/ch05/ex5_10.cpp
+++ b/ch05/ex5_10.cpp
@@ -6,21 +6,26 @@ int main()
     unsigned aCnt = 0, eCnt = 0, iCnt = 0, oCnt = 0, uCnt = 0;
     char ch;
     while (cin >> ch)
-        switch (tolower(ch))
+        switch (ch)
         {
             case 'a':
+            case 'A':
                 ++aCnt;
                 break;
             case 'e':
+            case 'E':
                 ++eCnt;
                 break;
             case 'i':
+            case 'I':
                 ++iCnt;
                 break;
             case 'o':
+            case 'O':
                 ++oCnt;
                 break;
             case 'u':
+            case 'U':
                 ++uCnt;
                 break;
         }


### PR DESCRIPTION
Although the original version is quite elegant, it didn't show the book intents:
> However, there are situations where the default switch behaviour is exactly what is needed. Each case label can have only a single value, but sometimes we have two or more values that share a common set of actions. In such instances, we omit a break statement, allowing the program to fall through multiple case labels.

My version might shows what book intends readers to do. Thanks for review.