### PR TITLE
modify ex16.5

### DIFF
--- a/ch16/ex16.5/main.cpp
+++ b/ch16/ex16.5/main.cpp
@@ -1,11 +1,12 @@
 /***************************************************************************
- *  @file       main.cpp
- *  @author     Alan.W
- *  @date       02  Feb 2014
- *              13  Oct 2014
- *  @remark     This code is for the exercises from C++ Primer 5th Edition
- *  @note
- ***************************************************************************/
+*  @file       main.cpp
+*  @author     Alan.W  wy-ei
+*  @date       02  Feb 2014
+*              13  Oct 2014
+*              30  Apr 2015
+*  @remark     This code is for the exercises from C++ Primer 5th Edition
+*  @note
+***************************************************************************/
 //!
 //! Exercise 16.5:
 //! Write a template version of the print function from § 6.2.4 (p. 217) that
@@ -16,22 +17,19 @@
 #include <iostream>
 #include <string>
 
-template<typename Arr>
-void print(const Arr& a)
-{
-    for(const auto& elem : a)
-        std::cout << elem << std::endl;
+template<size_t _N, typename _Ty>
+void print(const _Ty(&_Val)[_N]){
+    for (size_t i = 0; i < _N; i++){
+        std::cout << _Val[i] << " ";
+    }
 }
 
 int main()
 {
-    std::string p[] = {"ssss","aaa","ssssss"};
-    char c[] = {'a','b','c','d'};
-    int  i[] = {1};
-    print(i);
-    print(c);
-    print(p);
+    int vi[] = { 2, 3, 4, 5, 6, 7 };
+    std::string vs[] = { "aaa", "bbb", "ccc", "ddd" };
+    print(vi);
+    print(vs);
 
-    std::cout << "\nexit normally\n";
     return 0;
 }


### PR DESCRIPTION
because I think the old version is not match the author's intention.

there is a example at page 655
```
template<unsigned N,unsigned M>
int compare(const char (&p1)[N],const char(&p2)[M]){
    return strcmp(p1,p2);
}
```
I think we should do ex16.5 by this way.