### PR TITLE
Fix clang (OSX) compatibily

### DIFF
--- a/ch11/ex11_14.cpp
+++ b/ch11/ex11_14.cpp
@@ -16,7 +16,7 @@
 #include <map>
 #include <string>
 #include <algorithm>
-
+#include <vector>
 
 
 int main()

--- a/ch11/ex11_7.cpp
+++ b/ch11/ex11_7.cpp
@@ -12,6 +12,7 @@
 #include <map>
 #include <string>
 #include <algorithm>
+#include <vector>
 
 
 

--- a/ch11/ex11_8.cpp
+++ b/ch11/ex11_8.cpp
@@ -25,6 +25,7 @@
 #include <map>
 #include <string>
 #include <algorithm>
+#include <vector>
 
 
 

--- a/ch13/makefile
+++ b/ch13/makefile
@@ -6,10 +6,10 @@ OTHOBJS = ex13_42 ex13_48
 #	ex13_49_Message ex13_49_String ex13_49_StrVec 
 all:$(OBJECTS) $(OTHOBJS)
 
-ex13_42 : ex13_42.o ex13_42_TextQuery.o ex13_42_StrVec.o ex13_42_TextQuery.h ex13_42_StrVec.h
+ex13_42 : ex13_42.o ex13_42_TextQuery.o ex13_42_StrVec.o
 	$(CC) $(CCFLAGS) $(LOCFLAGS) -o $@ $^
 
-ex13_48 : ex13_48.o ex13_44_47.o ex13_44_47.h
+ex13_48 : ex13_48.o ex13_44_47.o 
 	$(CC) $(CCFLAGS) $(LOCFLAGS) -o $@ $^
 
 # tells make to use the file "../GNU_makefile_template", which

--- a/ch14/makefile
+++ b/ch14/makefile
@@ -8,67 +8,67 @@ OTHOBJS = ex14_02_TEST ex14_05_TEST ex14_07_TEST ex14_15_TEST ex14_22_TEST ex14_
 all:$(OBJECTS) $(OTHOBJS)
 
 
-ex14_02_TEST : ex14_02_TEST.o ex14_02.o ex14_02.h
+ex14_02_TEST : ex14_02_TEST.o ex14_02.o 
 	$(CC) $(CCFLAGS) $(LOCFLAGS) -o $@ $^
 
-ex14_05_TEST : ex14_05_TEST.o ex14_05.o ex14_05.h
+ex14_05_TEST : ex14_05_TEST.o ex14_05.o 
 	$(CC) $(CCFLAGS) $(LOCFLAGS) -o $@ $^
 
-ex14_07_TEST : ex14_07_TEST.o ex14_07.o ex14_07.h
+ex14_07_TEST : ex14_07_TEST.o ex14_07.o 
 	$(CC) $(CCFLAGS) $(LOCFLAGS) -o $@ $^
 
-ex14_15_TEST : ex14_15_TEST.o ex14_15.o ex14_15.h
+ex14_15_TEST : ex14_15_TEST.o ex14_15.o 
 	$(CC) $(CCFLAGS) $(LOCFLAGS) -o $@ $^
 
-ex14_16_StrBlobTest : ex14_16_StrBlobTest.o ex14_16_StrBlob.o ex14_16_StrBlob.h 
+ex14_16_StrBlobTest : ex14_16_StrBlobTest.o ex14_16_StrBlob.o 
 	$(CC) $(CCFLAGS) $(LOCFLAGS) -o $@ $^
 
-ex14_16_StringMain : ex14_16_StringMain.o ex14_16_String.o ex14_16_String.h 
+ex14_16_StringMain : ex14_16_StringMain.o ex14_16_String.o 
 	$(CC) $(CCFLAGS) $(LOCFLAGS) -o $@ $^
 
-ex14_16_StrVecMain : ex14_16_StrVecMain.o ex14_16_StrVec.o ex14_16_StrVec.h 
+ex14_16_StrVecMain : ex14_16_StrVecMain.o ex14_16_StrVec.o 
 	$(CC) $(CCFLAGS) $(LOCFLAGS) -o $@ $^
 
-ex14_18_StrBlobTest : ex14_18_StrBlobTest.o ex14_18_StrBlob.o ex14_18_StrBlob.h 
+ex14_18_StrBlobTest : ex14_18_StrBlobTest.o ex14_18_StrBlob.o 
 	$(CC) $(CCFLAGS) $(LOCFLAGS) -o $@ $^
 
-ex14_18_StringMain : ex14_18_StringMain.o ex14_18_String.o ex14_18_String.h 
+ex14_18_StringMain : ex14_18_StringMain.o ex14_18_String.o 
 	$(CC) $(CCFLAGS) $(LOCFLAGS) -o $@ $^
 
-ex14_18_StrVecMain : ex14_18_StrVecMain.o ex14_18_StrVec.o ex14_18_StrVec.h 
+ex14_18_StrVecMain : ex14_18_StrVecMain.o ex14_18_StrVec.o 
 	$(CC) $(CCFLAGS) $(LOCFLAGS) -o $@ $^
 
-ex14_26_StrBlobTest : ex14_26_StrBlobTest.o ex14_26_StrBlob.o ex14_26_StrBlob.h 
+ex14_26_StrBlobTest : ex14_26_StrBlobTest.o ex14_26_StrBlob.o 
 	$(CC) $(CCFLAGS) $(LOCFLAGS) -o $@ $^
 
-ex14_26_StringMain : ex14_26_StringMain.o ex14_26_String.o ex14_26_String.h 
+ex14_26_StringMain : ex14_26_StringMain.o ex14_26_String.o 
 	$(CC) $(CCFLAGS) $(LOCFLAGS) -o $@ $^
 
-ex14_26_StrVecMain : ex14_26_StrVecMain.o ex14_26_StrVec.o ex14_26_StrVec.h 
+ex14_26_StrVecMain : ex14_26_StrVecMain.o ex14_26_StrVec.o 
 	$(CC) $(CCFLAGS) $(LOCFLAGS) -o $@ $^
 
-ex14_22_TEST : ex14_22_TEST.o ex14_22.o ex14_22.h
+ex14_22_TEST : ex14_22_TEST.o ex14_22.o 
 	$(CC) $(CCFLAGS) $(LOCFLAGS) -o $@ $^
 
-ex14_23_TEST : ex14_23_TEST.o ex14_23.o ex14_23.h
+ex14_23_TEST : ex14_23_TEST.o ex14_23.o 
 	$(CC) $(CCFLAGS) $(LOCFLAGS) -o $@ $^
 
-ex14_24_TEST : ex14_24_TEST.o ex14_24.o ex14_24.h
+ex14_24_TEST : ex14_24_TEST.o ex14_24.o 
 	$(CC) $(CCFLAGS) $(LOCFLAGS) -o $@ $^
 
-ex14_32 : ex14_32.o  ex14_30_StrBlob.o ex14_32.h ex14_30_StrBlob.h
+ex14_32 : ex14_32.o  ex14_30_StrBlob.o 
 	$(CC) $(CCFLAGS) $(LOCFLAGS) -o $@ $^
 
-ex14_45_TEST : ex14_45_TEST.o ex14_45.o ex14_45.h
+ex14_45_TEST : ex14_45_TEST.o ex14_45.o 
 	$(CC) $(CCFLAGS) $(LOCFLAGS) -o $@ $^
 
-ex14_49_TEST : ex14_49_TEST.o ex14_49.o ex14_49.h
+ex14_49_TEST : ex14_49_TEST.o ex14_49.o 
 	$(CC) $(CCFLAGS) $(LOCFLAGS) -o $@ $^
 
-ex14_27_28_StrBlobTest : ex14_27_28_StrBlobTest.o ex14_27_28_StrBlob.o ex14_27_28_StrBlob.h
+ex14_27_28_StrBlobTest : ex14_27_28_StrBlobTest.o ex14_27_28_StrBlob.o 
 	$(CC) $(CCFLAGS) $(LOCFLAGS) -o $@ $^
 
-ex14_30_StrBlobTest : ex14_30_StrBlobTest.o ex14_30_StrBlob.o ex14_30_StrBlob.h
+ex14_30_StrBlobTest : ex14_30_StrBlobTest.o ex14_30_StrBlob.o 
 	$(CC) $(CCFLAGS) $(LOCFLAGS) -o $@ $^
 	
 # tells make to use the file "../GNU_makefile_template", which

--- a/ch17/makefile
+++ b/ch17/makefile
@@ -4,7 +4,7 @@ OBJECTS = ex17_10 ex17_11_12_13 ex17_1_2 ex17_14_15_16 ex17_17_18 \
 OTHOBJS = ex17_4_5_6_7_8 
 #ex17_3 ex17_3_TextQuery.cpp 
 
-ex17_4_5_6_7_8 : ex17_4_5_6_7_8.o ex17_4_5_6_7_8_SalesData.o ex17_4_5_6_7_8_SalesData.h
+ex17_4_5_6_7_8 : ex17_4_5_6_7_8.o ex17_4_5_6_7_8_SalesData.o 
 	$(CC) $(CCFLAGS) $(LOCFLAGS) -o $@ $^
 
 #ex17_3 :  ex17_3.o ex17_3_TextQuery.o ex17_3_TextQuery.h


### PR DESCRIPTION
1- makefile doesn't require headers as lib dependency 
2- <vector> should be explicitly declared 