### PR TITLE
array value type

### DIFF
--- a/ch03/ex3_31.cpp
+++ b/ch03/ex3_31.cpp
@@ -6,8 +6,9 @@ using std::cout; using std::endl;
 int main()
 {
     int ia[10];
-    for (size_t i=0; i<10; ++i)
-        ia[i] = i;
+    int posi=0;
+    for (size_t i=0; i<10; ++i,++posi)
+        ia[i] = posi;
 
     for (auto i : ia)
         cout << i << " ";


### PR DESCRIPTION
As we know, size_t is defined in cstdef header file, which may not convert to int