### PR TITLE
fix the bug of ex16.14.15 the overload of << and >> should be friend fun...

### DIFF
--- a/ch16/ex16.14.15/Screen.h
+++ b/ch16/ex16.14.15/Screen.h
@@ -31,13 +31,13 @@ public:
         return os;
     }
 
-    friend std::istream & operator>> ( std::istream &os , Screen &  c )
+    friend std::istream & operator>> ( std::istream &is , Screen &  c )
     {
             char a;
-            os>>a;
+            is>>a;
             std::string temp(H*W,a);
             c.contents = temp;
-            return os;
+            return is;
     }
 private:
     pos cursor = 0;

--- a/ch16/ex16.14.15/Screen.h
+++ b/ch16/ex16.14.15/Screen.h
@@ -8,6 +8,7 @@
 #define SCREEN_H
 
 #include <string>
+#include<iostream>
 
 template<unsigned H, unsigned W>
 class Screen {
@@ -19,9 +20,25 @@ public:
     char get() const              // get the character at the cursor
         { return contents[cursor]; }       // implicitly inline
     Screen &move(pos r, pos c);      // can be made inline later
-    Screen& operator<< (const char &c);
-    Screen& operator>> (char &c);
 
+    friend std::ostream & operator<< ( std::ostream &os , const Screen<H,W> & c ) 
+    {
+        unsigned int i,j;
+        for( i=0 ;i<c.height; i++ )
+        {
+                os<<c.contents.substr(0,W)<<std::endl;
+        }
+        return os;
+    }
+
+    friend std::istream & operator>> ( std::istream &os , Screen &  c )
+    {
+            char a;
+            os>>a;
+            std::string temp(H*W,a);
+            c.contents = temp;
+            return os;
+    }
 private:
     pos cursor = 0;
     pos height = H, width = W;
@@ -35,21 +52,4 @@ inline Screen<H, W>& Screen<H, W>::move(pos r, pos c)
     cursor = row + c;
     return *this;
 }
-
-
-template<unsigned H, unsigned W>
-inline Screen<H, W>& Screen<H, W>::operator<< (const char&c)
-{
-    contents[cursor] = c;
-    return *this;
-}
-
-template<unsigned H, unsigned W>
-inline Screen<H, W>& Screen<H, W>::operator>> (char &c)
-{
-    c = contents[cursor];
-    return *this;
-}
-
-
 #endif // SCREEN_H

--- a/ch16/ex16.14.15/main.cpp
+++ b/ch16/ex16.14.15/main.cpp
@@ -15,7 +15,8 @@
 //! Which, if any, friends are necessary in class Screen to make the input and
 //! output operators work? Explain why each friend declaration, if any, was
 //! needed.
-//!
+//    According to  the chapter of 14.2.1,the class of << and <<  should be a friend of this class.
+//
 
 #include"Screen.h"
 #include<iostream>
@@ -23,15 +24,14 @@
 int main()
 {
     Screen<5,5> scr('c');
-    char c0 = 'b', c1;
-    //! move the cursor
-    scr.move(2, 2);
-    //! output c0 to the screen
-    scr << c0;
-    //! input a char to c1 from the screen
-    scr >> c1;
-    //! test the result of c1
-    std::cout << c1 << std::endl;
+    Screen<5,5> scr2;
+
+    // output src to the screen
+    std::cout<<scr;
+    // input connet  to the  src 
+    std::cin>>scr2;
+    // test input
+    std::cout<<scr2;
 
     return 0;
 }


### PR DESCRIPTION
if the  code want to accomplish of function likes std::cout<< src or std::cin>>src , the overload function should be a friend of class 