### PR TITLE
Update ex15.7

### DIFF
--- a/ch15/ex15.7/limit_quote.cpp
+++ b/ch15/ex15.7/limit_quote.cpp
@@ -1,3 +1,9 @@
 #include "limit_quote.h"
 
-
+double Limit_quote::net_price(std::size_t n) const
+{
+  if (n > max_qty)
+    return max_qty * price * discount + (n - max_qty) * price;
+  else
+    return n * discount *price;
+}

--- a/ch15/ex15.7/limit_quote.h
+++ b/ch15/ex15.7/limit_quote.h
@@ -10,8 +10,7 @@ public:
     Limit_quote(const std::string& b, double p, std::size_t max, double disc):
         Quote(b,p), max_qty(max), discount(disc)    {   }
 
-    double net_price(std::size_t n) const override
-    { return n * price * (n < max_qty ? 1 - discount : 1 ); }
+    double net_price(std::size_t n) const override;
 
 private:
     std::size_t max_qty     = 0;


### PR DESCRIPTION
fixed a logic error in ex15.7.
The exercise says that `If the number of copies exceeds that limit, the normal price applies to those
purchased beyond the limit.` But the normal price applies all the book in the current version.