### PR TITLE
Theres no need for the alloc member to be contained by every StrVec

### DIFF
--- a/ch13/ex13_42_StrVec.cpp
+++ b/ch13/ex13_42_StrVec.cpp
@@ -1,5 +1,8 @@
 #include "ex13_42_StrVec.h"
 
+
+std::allocator<std::string> StrVec::alloc;
+
 void StrVec::push_back(const std::string &s)
 {
     chk_n_alloc();

--- a/ch13/ex13_49_StrVec.h
+++ b/ch13/ex13_49_StrVec.h
@@ -47,7 +47,7 @@ private:
     std::string *elements;
     std::string *first_free;
     std::string *cap;
-    std::allocator<std::string> alloc;
+    static std::allocator<std::string> alloc;
 };
 
 #endif


### PR DESCRIPTION
C++ Primer 5th edition errata: Pages 525–528: The alloc member of StrVec should be a static member of the class, not a data member of each object. To fix this error, add the static keyword to the declaration of alloc inside the StrVec class and provide a definition of the form
                                allocator<string> StrVec::alloc;
inside the implementation file for StrVec.