### PR TITLE
ex13.17: copy constructor should generates an unique serial number

### DIFF
--- a/ch13/ex13_17_1.cpp
+++ b/ch13/ex13_17_1.cpp
@@ -15,12 +15,14 @@
 class numbered {
 public:
     numbered() {
-        static int unique = 10;
         mysn = unique++;
     }
 
     int mysn;
+    static int unique;
 };
+
+int numbered::unique = 10;
 
 void f(numbered s) {
     std::cout << s.mysn << std::endl;

--- a/ch13/ex13_17_2.cpp
+++ b/ch13/ex13_17_2.cpp
@@ -15,16 +15,18 @@
 class numbered {
 public:
     numbered() {
-        static int unique = 10;
         mysn = unique++;
     }
 
     numbered(const numbered& n) {
-        mysn = n.mysn + 1;
+        mysn = unique++;
     }
 
     int mysn;
+    static int unique;
 };
+
+static int unique = 10;
 
 void f(numbered s) {
     std::cout << s.mysn << std::endl;
@@ -39,6 +41,6 @@ int main()
 }
 
 // output
-// 11
-// 12
 // 13
+// 14
+// 15

--- a/ch13/ex13_17_3.cpp
+++ b/ch13/ex13_17_3.cpp
@@ -15,16 +15,18 @@
 class numbered {
 public:
     numbered() {
-        static int unique = 10;
         mysn = unique++;
     }
 
     numbered(const numbered& n) {
-        mysn = n.mysn + 1;
+        mysn = unique++;
     }
 
     int mysn;
+    static int unique;
 };
+
+int numbered::unique = 10;
 
 void f(const numbered& s) {
     std::cout << s.mysn << std::endl;


### PR DESCRIPTION
the origin answer's copy constructor just increase a static number immediately, its behavior is not consistent as the constructor which generates an unique serial number in ex13.14.