### PR TITLE
changed to use integral comparison

### DIFF
--- a/ch05/ex5_19.cpp
+++ b/ch05/ex5_19.cpp
@@ -10,7 +10,7 @@ int main()
         cout << "Input two strings: ";
         string str1, str2;
         cin >> str1 >> str2;
-        cout << (str1 <= str2 ? str1 : str2) 
+        cout << (str1.size() <= str2.size() ? str1 : str2) 
              << " is less than the other. " << "\n\n"
              << "More? Enter yes or no: ";
         cin >> rsp;


### PR DESCRIPTION
When comparing string sizes, it's better to use an integral value as the compiler/machine -may- take alphabetical order into account over actual string length. depending on several factors. Additionally, we're specifically working with lengths so it's nice to have them presented as such for context, clarity and other comparisons.