### PR TITLE
Update ex5_21.cpp

### DIFF
--- a/ch05/ex5_21.cpp
+++ b/ch05/ex5_21.cpp
@@ -14,7 +14,7 @@ int main()
     bool no_twice = true;
     while (cin >> curr) 
     {
-        if (isupper(curr[0]) && prev == curr)
+        if ((0 < curr.length()) && isupper(curr[0]) && prev == curr)
         {
             cout << curr << ": occurs twice in succession." << endl;
             no_twice = false;


### PR DESCRIPTION
It seems that when the variable curr is an empty string the access of curr[0] didn't raise error. However I think it's safer to add the condition that curr.length() > 0