### PR TITLE
Fix Exercise 2.7

### DIFF
--- a/ch02/README.md
+++ b/ch02/README.md
@@ -123,7 +123,7 @@ have?
 
 (b): 31.4 "long double"
 
-(c): 1024 "float"
+(c): ERROR: The suffix f is valid only with floating point literals
 
 (d): 3.14 "long double"
 


### PR DESCRIPTION
The literal 1024f generate a compile error because the suffix f is only valid with floating point literals i.e  1024.f, 1024E0f, etc.