### PR TITLE
update ch05 ex5.17

### DIFF
--- a/ch05/ex5_17.cpp
+++ b/ch05/ex5_17.cpp
@@ -6,7 +6,7 @@ using std::cout; using std::vector;
 bool is_prefix(vector<int> const& lhs, vector<int> const& rhs)
 {
     if(lhs.size() > rhs.size())
-        is_prefix(rhs, lhs);
+        return is_prefix(rhs, lhs);
     for(unsigned i = 0; i != lhs.size(); ++i)
         if(lhs[i] != rhs[i]) return false;
     return true;


### PR DESCRIPTION
```cpp
bool is_prefix(const vector<int>& lhs, const vector<int>& rhs)
{
	if (lhs.size() > rhs.size())
		is_prefix(rhs, lhs);
	for (unsigned i = 0; i != lhs.size(); ++i)
		if (lhs[i] != rhs[i]) 
			return false;
	return true;
}
```
少了个 return，应该是 
```cpp
bool is_prefix(const vector<int>& lhs, const vector<int>& rhs)
{
	if (lhs.size() > rhs.size())
		return is_prefix(rhs, lhs);
	for (unsigned i = 0; i != lhs.size(); ++i)
		if (lhs[i] != rhs[i]) 
			return false;
	return true;
}
```
