### PR TITLE
fix some problems

### DIFF
--- a/ch09/README.md
+++ b/ch09/README.md
@@ -1,4 +1,4 @@
-﻿# Chapter 9. Sequential Containers
+# Chapter 9. Sequential Containers
 
 ## Exercise 9.1:
 >Which is the most appropriate—a vector, a deque, or a list—for the following program tasks?Explain the rationale for your choice.If there is no reason to prefer one or another container, explain why not.
@@ -234,18 +234,24 @@ if both elem1 and elem2 are the off-the-end iterator, nothing happened too.
 >Write a function that takes a forward_list<string> and two additional string arguments. The function should find the first string and insert the second immediately following the first. If the first string is not found, then insert the second string at the end of the list.
 
 ```cpp
-void find_and_insert(forward_list<string> &list, string const& to_find, string const& to_add)
+void find_and_insert(std :: forward_list<std :: string> &list, std :: string const& to_find, std :: string const& to_add)
 {
     auto prev = list.before_begin();
-    for (auto curr = list.begin(); curr != list.end(); prev = curr++)
-    {
-        if (*curr == to_find)
-        {
-            list.insert_after(curr, to_add);
-            return;
+    auto curr = list.begin();
+    bool find = false;
+    while(curr != list.end()){
+        if(*curr == to_find){
+            curr = list.insert_after(curr, to_add);
+            find = true;  
+        }else{
+            prev = curr;
+            ++curr;
         }
     }
-    list.insert_after(prev, to_add);
+    
+    if(!find){
+        list.insert_after(prev,to_add);
+    }    
 }
 ```
 

--- a/ch09/ex9_45.cpp
+++ b/ch09/ex9_45.cpp
@@ -18,7 +18,7 @@ using std::cout;
 using std::endl;
 
 // Exercise 9.45
-auto add_pre_and_suffix(string name, string const& pre, string const& su)
+auto add_pre_and_suffix(string name, string const& pre, string const& su) -> const string
 {
     name.insert(name.begin(), pre.cbegin(), pre.cend());
     return name.append(su);

--- a/ch10/ex10_30.cpp
+++ b/ch10/ex10_30.cpp
@@ -17,8 +17,7 @@ int main()
 {
     std::istream_iterator<int> in_iter(std::cin), eof;
     std::vector<int> vec;
-    while (in_iter != eof)
-        vec.push_back(*in_iter++);
+    std :: copy(in_iter, eof, back_inserter(vec));
     std::sort(vec.begin(), vec.end());
     std::copy(vec.cbegin(), vec.cend(), std::ostream_iterator<int>(std::cout, " "));
 }


### PR DESCRIPTION
- In ex9.28, the first string should refer to the first parameter in the parameter list, not the first occurrence in the string, i think your answer is not right.

- In ex9.45 iI run the code on Linux, the compiler(g++ 4.8.2) throws one warning('auto' type specifier without trailing return type). So I add the trailing type to avoid the warning, and it works well.