### PR TITLE
Update ch07 ex7_05.h

### DIFF
--- a/ch07/ex7_05.h
+++ b/ch07/ex7_05.h
@@ -8,7 +8,6 @@
 //
 //  1. add public access modifier for the function members
 //  2. use trailing return type 
-//  3. change return type from string to string const&, for better performance.
 //
 
 #ifndef CP5_ex7_05_h
@@ -21,8 +20,8 @@ class Person
     std::string name;
     std::string address;
 public:
-    auto get_name() const -> std::string const& { return name; }
-    auto get_addr() const -> std::string const& { return address; }
+    auto get_name() const -> std::string { return name; }
+    auto get_addr() const -> std::string { return address; }
 };
 
 #endif


### PR DESCRIPTION
I think we must not change return type from string to string const&. It will cause an error that we can modify the members of Person object by const_cast(). For example:

```cpp
int main(){
	Person person;
	const string& name = person.get_name();
	string& ref = const_cast<string& >( name );
	ref = "hx";
	cout << person.get_name();

	system( "pause" );
}
```