### PR TITLE
Update ex12_26.cpp

### DIFF
--- a/ch12/ex12_26.cpp
+++ b/ch12/ex12_26.cpp
@@ -16,7 +16,7 @@ void input_reverse_output_string(int n)
     auto const p = alloc.allocate(n);
     std::string s;
     auto q = p;
-    while (std::cin >> s && q != p + n)
+    while (q != p + n && std::cin >> s)
         alloc.construct(q++, s);
     
     while (q != p)


### PR DESCRIPTION
Exchange the order of the  bool evaluation because there is no need to ask input if pointer q reached the end of the dynamic memory.