### PR TITLE
Update ex12_14.cpp

### DIFF
--- a/ch12/ex12_14.cpp
+++ b/ch12/ex12_14.cpp
@@ -23,9 +23,8 @@ struct destination {
 
 connection connect(destination* pDest)
 {
-    std::shared_ptr<connection> pConn(new connection(pDest->ip, pDest->port));
-    std::cout << "creating connection(" << pConn.use_count() << ")" << std::endl;
-    return *pConn;
+    connection c(pDest->ip, pDest->port);
+	return c;
 }
 
 void disconnect(connection pConn)


### PR DESCRIPTION
Not sure why you want to allocate memory for the connection object inside the connect function when you only returns its value - the object itself will be destroyed anyways along with the shared_ptr.