### PR TITLE
Update ex13_08.h

### DIFF
--- a/ch13/ex13_08.h
+++ b/ch13/ex13_08.h
@@ -19,14 +19,10 @@ public:
     HasPtr(const std::string &s = std::string()) : ps(new std::string(s)), i(0) { }
     HasPtr(const HasPtr &hp) : ps(new std::string(*hp.ps)), i(hp.i) { }
     HasPtr& operator=(const HasPtr &rhs_hp) {
-        if(this != &rhs_hp){
-            std::string *temp_ps = new std::string(*rhs_hp.ps);
-            delete ps;
-            ps = temp_ps;
-            i = rhs_hp.i;
-        }
-        return *this;
-    }
+		*ps = *(rhs_hp.ps);
+		i = rhs_hp.i;
+		return *this;
+	}
 private:
     std::string *ps;
     int i;


### PR DESCRIPTION
There is no need to allocate new memory in copy-assignment operator. Just copy the string directly.