### PR TITLE
Update ex13_28.h

### DIFF
--- a/ch13/ex13_28.h
+++ b/ch13/ex13_28.h
@@ -19,16 +19,9 @@ public:
     TreeNode& operator=(const TreeNode &rhs);
     ~TreeNode() {
         if (--*count == 0) {
-            if (left) {
-                delete left;
-                left = nullptr;
-            }
-            if (right) {
-                delete right;
-                right = nullptr;
-            }
+            delete left;
+            delete right;
             delete count;
-            count = nullptr;
         }
     }
 


### PR DESCRIPTION
Please refer to: http://stackoverflow.com/questions/615355/is-there-any-reason-to-check-for-a-null-pointer-before-deleting
First, I don't think we need to check nullptr before delete, because we are not overloading delete. delete will check if the pointer is NULL for you, so it is safe to delete a null pointer.
Second, setting the pointer to nullptr after deleting it may be good sometimes, but it really doesn't look necessary in our case since the entire TreeNode object will be destroyed anyways and there is no way we can reuse the members.