### PR TITLE
Update ex13_34_36_37.h

### DIFF
--- a/ch13/ex13_34_36_37.h
+++ b/ch13/ex13_34_36_37.h
@@ -21,7 +21,6 @@ class Folder;
 
 class Message {
     friend void swap(Message &, Message &);
-    friend void swap(Folder &, Folder &);
     friend class Folder;
 public:
     explicit Message(const std::string &str = ""):contents(str) { }
@@ -47,7 +46,6 @@ private:
 void swap(Message&, Message&);
 
 class Folder {
-    friend void swap(Message&, Message&);
     friend void swap(Folder &, Folder &);
     friend class Message;
 public:
@@ -62,7 +60,7 @@ private:
     std::set<Message*> msgs;
 
     void add_to_Message(const Folder&);
-    void remove_to_Message();
+    void remove_from_Message();
 
     void addMsg(Message *m) { msgs.insert(m); }
     void remMsg(Message *m) { msgs.erase(m); }


### PR DESCRIPTION
The line: friend void swap(Folder &, Folder &); is redundant in "class Message". As you can see in my cpp file, swap function defined for Folder doesn't need access to Message's private members; and vice versa.