### PR TITLE
Patch 5

### DIFF
--- a/ch14/ex14_23.cpp
+++ b/ch14/ex14_23.cpp
@@ -147,8 +147,8 @@ bool operator>=(const StrVec &lhs, const StrVec &rhs)
 StrVec& StrVec::operator=(std::initializer_list<std::string> il)
 {
     auto data = alloc_n_copy(il.begin(), il.end());
-	free();
-	elements = data.first;
-	first_free = cap = data.second;
+    free();
+    elements = data.first;
+    first_free = cap = data.second;
     return *this;
 }

--- a/ch14/ex14_23.cpp
+++ b/ch14/ex14_23.cpp
@@ -146,6 +146,9 @@ bool operator>=(const StrVec &lhs, const StrVec &rhs)
 
 StrVec& StrVec::operator=(std::initializer_list<std::string> il)
 {
-    *this = StrVec(il);
+    auto data = alloc_n_copy(il.begin(), il.end());
+	free();
+	elements = data.first;
+	first_free = cap = data.second;
     return *this;
 }


### PR DESCRIPTION
Two issues with the original code:
1. Should destroy the elements and free the space before pointing to the new space.
2. *this = StrVec(il) is more expensive.