### PR TITLE
correct "noexcept" position

### DIFF
--- a/ch15/ex15.26/bulk_quote.h
+++ b/ch15/ex15.26/bulk_quote.h
@@ -15,7 +15,8 @@ public:
     { std::cout << "Bulk_quote : copy constructor\n"; }
 
     // move constructor
-    Bulk_quote(Bulk_quote&& bq) : Disc_quote(std::move(bq)) noexcept
+    //page 535, " In a constructor, noexcept appears between the parameter list and the : that begins the constructor initializer list"
+    Bulk_quote(Bulk_quote&& bq) noexcept : Disc_quote(std::move(bq))
     {
         std::cout << "Bulk_quote : move constructor\n";
     }


### PR DESCRIPTION
page 535, " In a constructor, noexcept appears between the parameter list and the : that begins the constructor initializer list".