### PR TITLE
Fixed exercise 2.31 (a). Fixed issue #494.

### DIFF
--- a/ch02/README.md
+++ b/ch02/README.md
@@ -463,7 +463,7 @@ whether the following assignments are legal. Explain how the top-level or
 low-level const applies in each case.
 
 ```cpp
-r1 = v2; // legal, top-level const in v2 is ignored.
+r1 = v2; // illegal, we cannot bind ‘const int’ to reference of type ‘int&’.
 p1 = p2; // illegal, p2 has a low-level const but p1 doesn't.
 p2 = p1; // legal, we can convert int* to const int*.
 p1 = p3; // illegal, p3 has a low-level const but p1 doesn't.


### PR DESCRIPTION
We cannot bind ‘const int’ to reference of type ‘int&’.