### PR TITLE
15.7 Incorrect formula in limit_quote.cpp

### DIFF
--- a/ch15/ex15.7/limit_quote.cpp
+++ b/ch15/ex15.7/limit_quote.cpp
@@ -3,7 +3,7 @@
 double Limit_quote::net_price(std::size_t n) const
 {
   if (n > max_qty)
-    return max_qty * price * discount + (n - max_qty) * price;
+    return (n - max_qty * discount) * price;
   else
-    return n * discount *price;
+    return n * price * (1 - discount);
 }


### PR DESCRIPTION
(max_qty * price * discount) calculates the discount rather than the price after discount
the formula should be:
max_qty * price * (1 - discount) + (n - max_qty) * price
which collapses nicely into:
(n - max_qty * discount) * price
same logic for the 'else' case