### PR TITLE
fix StrBlobPtr::operator!= only checking indices

### DIFF
--- a/ch12/ex12_19.h
+++ b/ch12/ex12_19.h
@@ -73,7 +73,13 @@ class StrBlobPtr {
 public:
     StrBlobPtr():curr(0) { }
     StrBlobPtr(StrBlob &a, size_t sz = 0):wptr(a.data), curr(sz) { }
-    bool operator!=(const StrBlobPtr& p) { return p.curr != curr; }
+    bool operator!=(const StrBlobPtr& p)
+	{
+		if (wptr.lock() == p.wptr.lock())
+			return (curr != p.curr);
+		else
+			return true;
+	}
     string& deref() const {
         auto p = check(curr, "dereference past end");
         return (*p)[curr];


### PR DESCRIPTION
Consider:

        StrBlob a({"bla", "blubb", "blob", "bob"});
	StrBlob b({"foo", "bar", "baz"});

	StrBlobPtr pa(a);
	StrBlobPtr pb(b);
	StrBlobPtr pc;

	std::cout << std::boolalpha;
	std::cout << "!(pa != pb) " << !(pa != pb) << std::endl;
	std::cout << "!(pa != pc) " << !(pa != pc) << std::endl;

The current implementation considers pa, pb and pc identical even though they point to different StrBlobs or no StrBlob at all. The proposed change checks for equality of the shared_ptr.