### PR TITLE
better to use size_type

### DIFF
--- a/ch03/ex3_17.cpp
+++ b/ch03/ex3_17.cpp
@@ -23,7 +23,7 @@ int main()
     for (string word; cin >> word; vec.push_back(word));
     for (auto &str : vec) for (auto &c : str) c = toupper(c);
 
-    for (int i = 0; i != vec.size(); ++i)
+    for (string::size_type i = 0; i != vec.size(); ++i)
     {
         if (i != 0 && i % 8 == 0) cout << endl;
         cout << vec[i] << " ";


### PR DESCRIPTION
better to use `size_type` for subscript/index instead of `int`