### PR TITLE
change 4.37 answer

### DIFF
--- a/ch04/README.md
+++ b/ch04/README.md
@@ -358,10 +358,10 @@ i *= static_cast<int>(d);
 >Rewrite each of the following old-style casts to use a named cast:
 ```cpp
 int i; double d; const string *ps; char *pc; void *pv;
-pv = (void*)ps; // pv = const_cast<string*>(ps); or pv = static_cast<void*>(const_cast<string*>(ps));
+pv = (void*)ps; // pc = reinterpret_cast<void*>(ps);
 i = int(*pc);   // i = static_cast<int>(*pc);
 pv = &d;        // pv = static_cast<void*>(&d);
-pc = (char*)pv; // pc = reinterpret_cast<char*>(pv);
+pc = (char*)pv; // pc = static_cast<char*>(pv);
 ```
 
 ##Exercise 4.38

--- a/ch05/ex5_19.cpp
+++ b/ch05/ex5_19.cpp
@@ -14,6 +14,6 @@ int main()
              << " is less than the other. " << "\n\n"
              << "More? Enter yes or no: ";
         cin >> rsp;
-    } while (tolower(rsp[0]) == 'y');
+    } while (!rsp.empty() && tolower(rsp[0]) == 'y');
     return 0;
 }

--- a/ch05/ex5_25.cpp
+++ b/ch05/ex5_25.cpp
@@ -14,7 +14,11 @@ int main(void)
         }
         catch (runtime_error err) 
         {
-            cout << err.what() << "\n";
+            cout << err.what() << "\nTry again? Enter y or n" << endl;
+            char c;
+            cin >> c;
+            if (!cin || c == 'n')
+                break;
         }
     }
 


### PR DESCRIPTION
Quoted
> When we use an old-style cast where a static_cast or a const_cast would be legal, the old-style cast does the same conversion as the respective named cast. If neither cast is legal, then an old-style cast performs a reinterpret_cast.

The original answer for 4.37 is correct, but according to the quoted, I think the answer that the author may prefer is:

for (a), because neither `static_cast<void*> (ps)` or `const_cast<void*>(ps)` is legal, we should use `reinterpret_cast`

for (d), because a pointer to any non`const` type can be converted to `void*`, so `static_cast` can work well according to [static_cast conversion](http://en.cppreference.com/w/cpp/language/static_cast), it also can be compiled using VS2015 compiler.