### PR TITLE
change 7.34 7.35 answer

### DIFF
--- a/ch02/README.md
+++ b/ch02/README.md
@@ -402,7 +402,8 @@ explain why.
 const int buf;      // illegal, buf is uninitialized const.
 int cnt = 0;        // legal.
 const int sz = cnt; // legal.
-++cnt; ++sz;        // illegal, attempt to write to const object(sz).
+++cnt;              // legal.
+++sz;               // illegal, attempt to write to const object(sz).
 ```
 
 ## Exercise 2.27

--- a/ch07/README.md
+++ b/ch07/README.md
@@ -152,6 +152,12 @@ There is an error in
     dummy_fcn(pos height)
                ^
     Unknown type name 'pos'
+    
+    pos cursor = 0;
+     ^
+    pos height = 0, width = 0;
+     ^
+    Unknown type name 'pos'
 
 ## Exercise 7.35
 
@@ -175,27 +181,18 @@ Type Exercise::setVal(Type parm) {  // first is `string`, second is `double`
 
 **fixed**
 
-changed
+>in a class, if a member uses a name from an outer scope and that name is a type, then the class may not subsequently redefine that name
+Although it is an error to redefine a type name, compilers are not required to diagnose this error. Some compilers will quietly accept such code, even though the program is in error.
 
-```cpp
-Type Exercise::setVal(Type parm) {
-    val = parm + initVal();
-    return val;
-}
-```
-to
-```cpp
-Exercise::Type Exercise::setVal(Type parm) {
-    val = parm + initVal();
-    return val;
-}
-```
+change `typedef double Type` to `typedef double anotherType`
 
 and `Exercise::initVal()` should be defined.
 
+
+
 ## Exercise 7.36
 
->In this case, the constructor initializer makes it appear as if `base` is initialized with `i` and then `base` is used to initialize `rem`. However, `base` is initialized first. The effect of this initializer is to initialize `rem` with the undefined value of `base`!
+>In this case, the constructor initializer makes it appear as if `base` is initialized with `i` and then `base` is used to initialize `rem`. However, `rem` is initialized first. The effect of this initializer is to initialize `rem` with the undefined value of `base`!
 
 **fixd**
 ```cpp

--- a/ch11/README.md
+++ b/ch11/README.md
@@ -130,7 +130,7 @@ The above code won't compile because the subscript operator might insert an elem
 >Our program does no checking on the validity of either input file. In particular, it assumes that the rules in the transformation file are all sensible.
 What would happen if a line in that file has a key, one space, and then the end of the line? Predict the behavior and then check it against your version of the program.
 
-If so, a key-value pair is going to be added into the map: `{key, ""}`. As a result, any key would be replaced with empty string.
+If so, a key-value pair will be `{key, " "}`(" ".size() !> 1), which cannot be added into the map. As a result, the key would not be replaced with any string.
 
 ## Exercise 11.37:
 >What are the advantages of an unordered container as compared to the ordered version of that container? What are the advantages of the ordered version?

--- a/ch14/README.md
+++ b/ch14/README.md
@@ -92,7 +92,7 @@ see [Exercise 14.2](# Exercise-142).
 - (b) 10 24.95 0-210-99999-9
 
 - (a) correct format.
-- (b) ilegal input. But `0-210-99999-9` will be converted to a float stored in this object. As a result, the data inside will be a wrong one.
+- (b) ilegal input. But `.95` will be converted to a float stored in this object. As a result, the data inside will be a wrong one.
 Output: `10 24 22.8 0.95`
 
 check [Test](ex14_02_TEST.cpp)


### PR DESCRIPTION
for 7.35
>in a class, if a member uses a name from an outer scope and that name is a type, then the class may not subsequently redefine that name
Although it is an error to redefine a type name, compilers are not required to diagnose this error. Some compilers will quietly accept such code, even though the program is in error.

so should change `typedef double Type` to `typedef double anotherType`.

In addition, just from the perspective of grammar, not considering logic, others can be unchanged.