### PR TITLE
fix exercise 16.34

### DIFF
--- a/ch16/ex16.32.33.34.35.36/main.cpp
+++ b/ch16/ex16.32.33.34.35.36/main.cpp
@@ -35,7 +35,7 @@
 //          compare("hi", "world");
 //  It didn't complie, as two types are different, the first type being char[3] , second char[6]
 //          compare("bye", "dad");
-//   the type should be pointer to char i.e. char*
+//   the type should be char[4];
 //
 // Exercise 16.35:
 // Which, if any, of the following calls are errors? If the call is legal, what


### PR DESCRIPTION
when function parameter is reference, array will not be converted to pointer.
so for 
```
template <class T> int compare(const T&, const T&);
compare("bye", "dad");
```
`T` should be char[4].