### PR TITLE
Typo and error in 7.36

### DIFF
--- a/ch07/README.md
+++ b/ch07/README.md
@@ -197,10 +197,10 @@ and `Exercise::initVal()` should be defined.
 
 >In this case, the constructor initializer makes it appear as if `base` is initialized with `i` and then `base` is used to initialize `rem`. However, `base` is initialized first. The effect of this initializer is to initialize `rem` with the undefined value of `base`!
 
-**fixd**
+**fixed**
 ```cpp
 struct X {
-  X (int i, int j): base(i), rem(base % j) { }
+  X (int i, int j): base(i), rem(i % j) { }
   int base, rem;
 };
 ```


### PR DESCRIPTION
Fixes a small typo. Also, while the code in 7.36 is technically correct, it uses a member to initialize another member. This goes against best practices: 

>Best Practices: It is a good idea to write constructor initializers in the same order as the members are declared. Moreover, when possible, avoid using members to initialize other members.