### PR TITLE
Update ex6_21

### DIFF
--- a/ch06/ex6_21.cpp
+++ b/ch06/ex6_21.cpp
@@ -9,7 +9,7 @@
 #include <iostream>
 using std::cout;
 
-int larger_one(const int i, const int *p)
+int larger_one(const int i, const int *const p)
 {
     return (i > *p) ? i : *p;
 }


### PR DESCRIPTION
The original solution would allow you to modify the pointer itself inside larger_one function.  Applying a 2nd const ensures that the function can't modify the address stored in 'p' pointer.