### PR TITLE
Update ex6_47.cpp

### DIFF
--- a/ch06/ex6_47.cpp
+++ b/ch06/ex6_47.cpp
@@ -4,15 +4,16 @@
 //
 //  Created by pezy on 14/10/30.
 //
+// To turn off debugging, uncomment the following line, or compile the program with '-D NDEBUG' switch
+//#define NDEBUG 
+
 #include <iostream>
 #include <vector>
 using std::vector; using std::cout; using std::endl;
 
-#define NDEBUG
-
 void printVec(vector<int> &vec)
 {
-#ifdef NDEBUG
+#ifndef NDEBUG
     cout << "vector size: " << vec.size() << endl;
 #endif
     if (!vec.empty())


### PR DESCRIPTION
You only want to print debugging information when debugging is NOT disabled (in other words, when NDEBUG is not defined; NDEBUG stands for No Debugging).  The original version was doing the opposite (printing vector size when debugging was disabled).  Also, at least on my compiler the #define NDEBUG line had to be at the very beginning of the file, otherwise it wouldn't work.