### PR TITLE
Update ex7_22.h

### DIFF
--- a/ch07/ex7_22.h
+++ b/ch07/ex7_22.h
@@ -11,7 +11,7 @@
 #include <string>
 #include <iostream>
 
-struct Person {
+class Person {
     friend std::istream &read(std::istream &is, Person &person);
     friend std::ostream &print(std::ostream &os, const Person &person);
 


### PR DESCRIPTION
While the original (using 'struct') was technically correct, I believe using 'class' makes more sense here.  Especially in the light of the following quote from the book: 
"As a matter of programming style, when we define a class intending for all of its
members to be public, we use struct. If we intend to have private members,
then we use class."