### PR TITLE
Fix 7.44

### DIFF
--- a/ch07/README.md
+++ b/ch07/README.md
@@ -281,7 +281,7 @@ private:
 ## [Exercise 7.43](ex7_43.cpp)
 ## Exercise 7.44
 
-illegal, cause there are ten elements, each would be default initialized. But no default initializer for the temporary object.
+illegal, cause there are ten elements, each would be value initialized. But no default constructor for the objects of type `NoDefault`.
 
 ## Exercise 7.45
 


### PR DESCRIPTION
**Exercise 7.44:**

```c++
class NoDefault {
public:
    NoDefault(const std::string&);
    // additional members follow, but no other constructors
};
```

Is the following declaration legal? If not, why not? `vector<NoDefault> vec(10);`

In C++ Primer 5 § 7.5.3:

> Value initialization happens:
> - When we explicitly request value initialization by writing an expressions of the form `T()` where `T` is the name of a type (The `vector` constructor that takes a single argument to specify the `vector`’s size (§ 3.3.1, p. 98) uses an argument of this kind to value initialize its element initializer.)