### PR TITLE
Exercise 4.25

### DIFF
--- a/ch04/README.md
+++ b/ch04/README.md
@@ -224,7 +224,7 @@ It's contradictory obviously.
 ## Exercise 4.25
 >What is the value of ~'q' << 6 on a machine with 32-bit ints and 8 bit chars, that uses Latin-1 character set in which 'q' has the bit pattern 01110001?
 
-The final value in decimal is `-7296`.  
+The final value in decimal is 128.  
 
 ## Exercise 4.26
 >In our grading example in this section, what would happen if we used unsigned int as the type for quiz1?


### PR DESCRIPTION
Due it is a 8-bits representation:

Binary value: 100000000

char is signed by default; therefore the value should be 128