### PR TITLE
6.39(a) change to 'legal'

### DIFF
--- a/ch06/README.md
+++ b/ch06/README.md
@@ -293,7 +293,7 @@ decltype(arrStr)& arrPtr(int i)
 
 ## Exercise 6.39
 
-(a) illegal
+(a) legal
 
 (b) illegal
 


### PR DESCRIPTION
int calc(int, int);
int calc(const int, const int);
Legal. Top-level const is ignored.