### PR TITLE
Fix 6.53

### DIFF
--- a/ch06/README.md
+++ b/ch06/README.md
@@ -380,7 +380,7 @@ int calc(const int&, const int&); // calls lookup(const int&)
 (b)
 ```cpp
 int calc(char*, char*); // calls lookup(char*)
-int calc(const char*, const char*); calls lookup(const char *)
+int calc(const char*, const char*); // calls lookup(const char *)
 ```
 (c)
 


### PR DESCRIPTION
(b)
```cpp
int calc(char*, char*); // calls lookup(char*)
int calc(const char*, const char*); calls lookup(const char *)
```
Missing a comments
(b)
```cpp
int calc(char*, char*); // calls lookup(char*)
int calc(const char*, const char*); // calls lookup(const char *)
```