### PR TITLE
Fix the answer to exercise 5.13-b

### DIFF
--- a/ch05/README.md
+++ b/ch05/README.md
@@ -165,9 +165,10 @@ Colloquial term used to refer to the problem of how to process nested if stateme
     }
 (b) // Error: control bypass an explicitly initialized variable ix.
     unsigned index = some_value();
+    int ix;
     switch (index) {
         case 1:
-            int ix;
+            ix = get_value();
             ivec[ ix ] = index;
             break;
         default:


### PR DESCRIPTION
ix under case "1" is not initialized, UB will happen. 
So bring the definition of ix out of the switch statement.