### PR TITLE
Fixed exercise 2.29

### DIFF
--- a/ch02/README.md
+++ b/ch02/README.md
@@ -436,8 +436,8 @@ following assignments are legal? Explain why.
 
 ```cpp
 i = ic;     // legal.
-p1 = p3;    // illegal. p3 is a const pointer to const int.
-p1 = &ic;   // illegal. ic is a const int.
+p1 = p3;    // legal.
+p1 = &ic;   // legal.
 p3 = &ic;   // illegal. p3 is a const pointer.
 p2 = p1;    // illegal. p2 is a const pointer.
 ic = *p3;   // illegal. ic is a const int.


### PR DESCRIPTION
p1 = p3 is legal.
p1 is not a const pointer that points to a const int, hence what points to can be changed, no matter if p3 is a const pointer or not, neither if it points to a const int or not.

Similar as above, p1 = &ic is legal.

Here's a short code that can be compiled that proofs the above:

```cpp
#include <iostream>

int main()
{
	const int i2 = 6;
	const int *const p3 = &i2;
	//legal, p1 is not a constant pointer and can change what points to
	//no matter if p3 is contant or not.
	const int *p1 = p3; 

	const int ic = 5;
	//legal, similar as above
	p1 = &ic;
	std::cout << *p1 << std::endl;
	return 0;
}
```