### PR TITLE
Update ex10.24.cpp

### DIFF
--- a/ch10/ex10_24.cpp
+++ b/ch10/ex10_24.cpp
@@ -30,7 +30,7 @@ auto check_size(string const& str, size_t sz)
 
 int main()
 {
-    vector<int> vec{ 0, 1, 2, 3, 4, 5, 6, 7 };
+    vector<size_t> vec{ 0, 1, 2, 3, 4, 5, 6, 7 };
     string str("123456");
     auto result = find_if(vec.begin(), vec.end(), bind(check_size, str, std::placeholders::_1));
     if (result != vec.end())


### PR DESCRIPTION
The type of vector has to be restricted to size_t and not int since size of string will always be unsigned. So it's better to restrict negative values in the vector since negative value in the vector gives and incorrect solution.
This will also solve the issue https://github.com/Mooophy/Cpp-Primer/issues/676