### PR TITLE
Update ex7_53.h

### DIFF
--- a/ch07/ex7_53.h
+++ b/ch07/ex7_53.h
@@ -12,7 +12,7 @@ class Debug {
 public:
     constexpr Debug(bool b = true) : rt(b), io(b), other(b) { }
     constexpr Debug(bool r, bool i, bool o) : rt(r), io(i), other(o) { }
-    constexpr bool any() { return rt || io || other; }
+    constexpr bool any() const { return rt || io || other; }
     
     void set_rt(bool b) { rt = b; }
     void set_io(bool b) { io = b; }


### PR DESCRIPTION
Won't compile since `c++14` using `g++` without declaring `any` as const member function.