### PR TITLE
Update README.md

### DIFF
--- a/ch13/README.md
+++ b/ch13/README.md
@@ -132,7 +132,7 @@ Yes, it does. Because, as described, the newly defined copy constructor can hand
 ## Exercise 13.16:
 >What if the parameter in f were const numbered&? Does that change the output? If so, why? What output gets generated?
 
-Yes, the output will change. Because no copy operation happens within function `f`. Thus, the three Output are the same.
+No, the output has not changed. Because the copy constructor lets a, b, and c have different mysn value. Therefore, the three Output are different.
 
 ## Exercise 13.17
 > Write versions of numbered and f corresponding to the previous three exercises and check whether you correctly predicted the output.


### PR DESCRIPTION
The analysis of 13.16 is wrong, and for both 13.14 and 13.15 answers, the results of 13.16 have not changed. The source code of 13.16 has introduced the copy constructor of 13.15, so the copy constructor gives b, c different mysn values, and the three Output are different.