### PR TITLE
fix ex12_02

### DIFF
--- a/ch12/ex12_02.h
+++ b/ch12/ex12_02.h
@@ -30,16 +30,6 @@ public:
         data->pop_back();
     }
 
-    std::string& front() {
-        check(0, "front on empty StrBlob");
-        return data->front();
-    }
-
-    std::string& back() {
-        check(0, "back on empty StrBlob");
-        return data->back();
-    }
-
     const std::string& front() const {
         check(0, "front on empty StrBlob");
         return data->front();
@@ -47,6 +37,19 @@ public:
     const std::string& back() const {
         check(0, "back on empty StrBlob");
         return data->back();
+    }
+    std::string& front() {
+        return const_cast<std::string&>(
+                static_cast<const StrBlob&>(*this)
+                    .front()
+                );
+    }
+
+    std::string& back() {
+        return const_cast<std::string&>(
+                static_cast<const StrBlob&>(*this)
+                    .back()
+                );
     }
 
 private:


### PR DESCRIPTION
to avoid code duplication caused by overloading of const member function, "casting away constness" should be applied.
according to no.7 principle in effective c++ .