### PR TITLE
Fix Exercise 14.3(c) 

### DIFF
--- a/ch14/README.md
+++ b/ch14/README.md
@@ -25,7 +25,7 @@
 - (c) `svec1 == svec2`
 - (d) `"svec1[0] == "stone"`
 
-(a) neither. (b) `string` (c) `vector` (d) `string`
+(a) neither. (b) `string` (c) Both `vector` and `string`. (d) `string`
 
 -----
 


### PR DESCRIPTION
As svec1 and svec2 are vectors of strings, `svec1 == svec2` will use `==` operator defined for vectors, as well as, that defined for strings(as every member in svec1 will be compared for equality with corresponding member in svec2 using `== `defined for strings).

Reference - [https://en.cppreference.com/w/cpp/container/vector/operator_cmp](url)

From above link - 

> 1-2) Checks if the contents of lhs and rhs are equal, that is, they have the same number of elements and each element in lhs compares equal with the element in rhs at the same position.