### PR TITLE
fix: fix 13.16

### DIFF
--- a/ch13/README.md
+++ b/ch13/README.md
@@ -132,7 +132,7 @@ Yes, it does. Because, as described, the newly defined copy constructor can hand
 ## Exercise 13.16:
 >What if the parameter in f were const numbered&? Does that change the output? If so, why? What output gets generated?
 
-Yes, the output will change. Because no copy operation happens within function `f`. Thus, the three Output are the same.
+No, the output will change but the three Output are not the same, because copy constructor has been executed during variable definition.
 
 ## Exercise 13.17
 > Write versions of numbered and f corresponding to the previous three exercises and check whether you correctly predicted the output.


### PR DESCRIPTION
you can verify it by execute code below:
```c++
#include <iostream>

using namespace std;

class X {
        public:
                int mysn = 0;
                X() {}
                X(const X&orig): mysn(orig.mysn + 1) {
                        cout << "copy constructor " << (orig.mysn + 1) << endl;
                }
};

void f (const X &x) {
        cout << x.mysn << endl;
}

int main() {
        X a, b = a, c = b;
        f(a);
        f(b);
        f(c);
        return 0;
}
```