### PR TITLE
[Ex 6.36, 6.37] Remove parameter

### DIFF
--- a/ch06/README.md
+++ b/ch06/README.md
@@ -266,7 +266,7 @@ the recursive function will always use `val` as the parameter. *a recursion loop
 ## Exercise 6.36
 
 ```cpp
-string (&func(string (&arrStr)[10]))[10]
+string (&func())[10]
 ```
 
 ## Exercise 6.37

--- a/ch06/README.md
+++ b/ch06/README.md
@@ -272,13 +272,16 @@ string (&func())[10]
 ## Exercise 6.37
 
 ```cpp
+// type alias
 using ArrT = string[10];
-ArrT& func1(ArrT& arr);
+ArrT& func1();
 
-auto func2(ArrT& arr) -> string(&)[10];
+// trailing return
+auto func2() -> string(&)[10];
 
+// decltype
 string arrS[10];
-decltype(arrS)& func3(ArrT& arr);
+decltype(arrS)& func3();
 ```
 
 I pefer the first one. because it is more simpler to me.


### PR DESCRIPTION
Exercise 6.36 and 6.37

The problem asks to write the declaration for a function that returns a reference. It doesn't mention about taking an array as a parameter. One of the applications of the function that returns a reference without parameter is the getter function of a class. I suggest removing the unnecessary parameter to make the function declaration simpler and also to address the requirement.